### PR TITLE
Task Edit

### DIFF
--- a/app/assets/stylesheets/_task_edit.scss
+++ b/app/assets/stylesheets/_task_edit.scss
@@ -1,0 +1,85 @@
+.task_edit {
+  height: 600px;
+  width: 600px;
+  margin: 20px auto;
+  background-color: $white;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.25);
+
+  .title {
+    height: 30px;
+    float: left;
+    font-size: 25px;
+    font-weight: bold;
+    padding-top: 20px;
+    padding-left: 40px;
+    padding-bottom: 20px;
+    color: $gray;
+  }
+
+  .back_buttun {
+    height: 14px;
+    width: 30px;
+    float: left;
+    color: $white;
+    font-size: 13px;
+    margin-top: 25px;
+    margin-right: 30px;
+    margin-left: 310px;
+    margin-bottom: 25px;
+    background-color: $gray;
+    border-color: transparent;
+    border-radius: 100px;
+    box-shadow: none;
+    cursor: pointer;
+    font-weight: bold;
+    line-height: 20px;
+    padding: 8px 16px;
+    text-align: center;
+    white-space: nowrap;
+    text-decoration: none;
+  }
+
+  .form {
+    padding: 35px;
+
+    .field {
+      padding: 5px;
+
+      #task_title, #task_scheduled, #task_priority, #task_completion {
+        height: 43px;
+        width: 490px;
+      }
+
+      #task_body {
+        height: 86px;
+        width: 490px;
+      }
+
+      .date, .text {
+        color: $gray;
+        font-size: 13px;
+      }
+
+    }
+
+    .actions {
+
+      .btn {
+        height: 47px;
+        width: 510px;
+        margin-top: 12px;
+        background-color: $gray;
+        color: $white;
+        border-radius: 80px;
+        box-shadow: none;
+        cursor: pointer;
+        font-size: 16px;
+        font-weight: bold;
+        line-height: 20px;
+        padding: 6px 16px;
+        text-align: center;
+        white-space: nowrap;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_task_edit.scss
+++ b/app/assets/stylesheets/_task_edit.scss
@@ -1,5 +1,5 @@
 .task_edit {
-  height: 600px;
+  height: 590px;
   width: 600px;
   margin: 20px auto;
   background-color: $white;
@@ -24,7 +24,7 @@
     font-size: 13px;
     margin-top: 25px;
     margin-right: 30px;
-    margin-left: 310px;
+    margin-left: 230px;
     margin-bottom: 25px;
     background-color: $gray;
     border-color: transparent;

--- a/app/assets/stylesheets/_task_new.scss
+++ b/app/assets/stylesheets/_task_new.scss
@@ -1,7 +1,7 @@
 .task_new {
-  height: 500px;
+  height: 530px;
   width: 600px;
-  margin: 50px auto;
+  margin: 20px auto;
   background-color: $white;
   box-shadow: 0 1px 4px rgba(0,0,0,0.25);
 
@@ -18,7 +18,7 @@
     padding: 35px;
 
     .field {
-      padding: 10px;
+      padding: 5px;
 
       #task_title, #task_scheduled, #task_priority {
         height: 43px;
@@ -28,6 +28,11 @@
       #task_body {
         height: 86px;
         width: 490px;
+      }
+
+      .date, .text {
+        color: $gray;
+        font-size: 13px;
       }
 
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,4 +5,5 @@
 @import "topbar";
 @import "contents";
 @import "task_new";
+@import "task_edit";
 @import "flash";

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,6 +26,19 @@ class TasksController < ApplicationController
     end
   end
 
+  def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    @task = Task.find(params[:id])
+    if @task.update(task_params)
+      redirect_to root_path, notice: "タスクが変更されました"
+    else
+      render :edit, alert: "変更に失敗しました"
+    end
+  end
+
   private
 
   def task_params

--- a/app/views/shared/_task.html.haml
+++ b/app/views/shared/_task.html.haml
@@ -1,10 +1,11 @@
-.task
-  .title
-    = task.title
-  .scheduled
-    = task.scheduled
-  .completion
-    = task.completion
-  .priority
-    = task.priority
-  = link_to '削除', task_path(task), class: 'delete_buttun', method: :delete, data: {confirm: "このタスクを本当に削除しますか?"}
+= link_to edit_task_path(task.id) do
+  .task
+    .title
+      = task.title
+    .scheduled
+      = task.scheduled
+    .completion
+      = task.completion
+    .priority
+      = task.priority
+    = link_to '削除', task_path(task), class: 'delete_buttun', method: :delete, data: {confirm: "このタスクを本当に削除しますか?"}

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,6 +1,6 @@
 = render "shared/topbar"
 .task_edit
-  .title タスク変更
+  .title タスク変更・閲覧
   = link_to root_path do
     .back_buttun 戻る
   .form

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,0 +1,29 @@
+= render "shared/topbar"
+.task_edit
+  .title タスク変更
+  = link_to root_path do
+    .back_buttun 戻る
+  .form
+    = form_for(@task) do |f|
+      .field
+        .field-input
+          .text タイトル
+          = f.text_field :title, placeholder: "タイトル", maxlength: "15"
+      .field
+        .field-input
+          .text タスク内容
+          = f.text_area :body, placeholder: "タスク内容", maxlength: "30"
+      .field
+        .field-input
+          .date 予定日
+          = f.date_field :scheduled
+      .field
+        .field-input
+          .text 優先順位
+          = f.number_field :priority, placeholder: "優先順位を選択", min:1, max:12
+      .field
+        .field-input
+          .date 完了日
+          = f.date_field :completion
+      .actions
+        = f.submit "変更する", class: 'btn', data: {confirm: "このタスクを変更しますか?"}

--- a/app/views/tasks/new.html.haml
+++ b/app/views/tasks/new.html.haml
@@ -5,15 +5,19 @@
     = form_for(@task) do |f|
       .field
         .field-input
-          = f.text_field :title, placeholder: "タイトル", maxlength: "50"
+          .text タイトル
+          = f.text_field :title, placeholder: "タイトル", maxlength: "15"
       .field
         .field-input
-          = f.text_area :body, placeholder: "タスク内容"
+          .text タスク内容
+          = f.text_area :body, placeholder: "タスク内容", maxlength: "30"
       .field
         .field-input
+          .date 予定日
           = f.date_field :scheduled
       .field
         .field-input
+          .text 優先順位
           = f.number_field :priority, placeholder: "優先順位を選択", min:1, max:12
       .actions
         = f.submit "登録する", class: 'btn', data: {confirm: "このタスクを登録しますか?"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root  'tasks#index'
-  resources :tasks, only: [:new, :create, :destroy]
+  resources :tasks, only: [:new, :create, :destroy, :edit, :update]
 end


### PR DESCRIPTION
# What
タスク変更・閲覧
# Why
タスクの変更・閲覧をするため
# 実装内容
•タスク一覧の該当の行を押すとタスク変更・閲覧画面に遷移する。
•タスク変更・閲覧画面にタイトル、タスクの内容、予定日、完了日、優先順位を表示する。
•画面表示時点で登録済みの値をフォームに表示。
•値を変更し、変更ボタンを押すとタスク一覧に戻る。
•戻るボタンを押すとタスク一覧に戻る。
•値変更前に確認ダイアログを表示。
