### PR TITLE
Fix 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://todowebmr.herokuapp.com/
 |------|----|-------|
 |title|string|index:true, null: false|
 |body|text|null: false|
-|scheduled|string|null: false|
-|finished|string|-------|
+|scheduled|date|null: false|
+|finished|date|-------|
 |priority|string|null: false|
+|unfinished|boolean|null: false,default: true|

--- a/app/assets/stylesheets/_finished.scss
+++ b/app/assets/stylesheets/_finished.scss
@@ -83,7 +83,15 @@
       margin-top: 15px;
     }
 
-    .delete {
+    .finished_b {
+      width: 120px;
+      float: left;
+      color: $gray;
+      font-size: 13px;
+      margin-top: 15px;
+    }
+
+    .delete_b {
       width: 120px;
       float: left;
       color: $gray;
@@ -149,6 +157,26 @@
       color: $gray;
       font-size: 13px;
       margin-top: 15px;
+    }
+
+    .finished_buttun {
+      height: 14px;
+      width: 30px;
+      float: left;
+      color: $white;
+      font-size: 13px;
+      margin-top: 6px;
+      background-color: $gray;
+      border-color: transparent;
+      border-radius: 100px;
+      box-shadow: none;
+      cursor: pointer;
+      font-weight: bold;
+      line-height: 20px;
+      padding: 8px 16px;
+      text-align: center;
+      white-space: nowrap;
+      text-decoration: none;
     }
 
     .delete_buttun {

--- a/app/assets/stylesheets/_unfinished.scss
+++ b/app/assets/stylesheets/_unfinished.scss
@@ -82,7 +82,15 @@
       margin-top: 15px;
     }
 
-    .delete {
+    .finished_b {
+      width: 120px;
+      float: left;
+      color: $gray;
+      font-size: 13px;
+      margin-top: 15px;
+    }
+
+    .delete_b {
       width: 120px;
       float: left;
       color: $gray;
@@ -148,6 +156,26 @@
       color: $gray;
       font-size: 13px;
       margin-top: 15px;
+    }
+
+    .finished_buttun {
+      height: 14px;
+      width: 30px;
+      float: left;
+      color: $white;
+      font-size: 13px;
+      margin-top: 6px;
+      background-color: $gray;
+      border-color: transparent;
+      border-radius: 100px;
+      box-shadow: none;
+      cursor: pointer;
+      font-weight: bold;
+      line-height: 20px;
+      padding: 8px 16px;
+      text-align: center;
+      white-space: nowrap;
+      text-decoration: none;
     }
 
     .delete_buttun {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body, :scheduled, :finished, :priority)
+    params.require(:task).permit(:title, :body, :scheduled, :finished, :priority, :unfinished)
   end
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,7 +4,7 @@ class Task < ActiveRecord::Base
   validates :body, presence: true
   validates :scheduled, presence: true
   validates :finished, presence: true, on: :update
-  validates :priority, presence: true, uniqueness: true
+  validates :priority, presence: true
 #scope
   scope :unfinished, -> { where(unfinished: ["1"]) }
   scope :finished, -> { where(unfinished: ["0"]) }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,7 +5,6 @@ class Task < ActiveRecord::Base
   validates :scheduled, presence: true
   validates :finished, presence: true, on: :update
   validates :priority, presence: true, uniqueness: true
-  validates :unfinished, presence: true
 #scope
   scope :unfinished, -> { where(unfinished: ["1"]) }
   scope :finished, -> { where(unfinished: ["0"]) }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,14 @@
 class Task < ActiveRecord::Base
-  scope :unfinished, -> { where(finished: ["", nil]) }
-  scope :finished, -> { where.not(finished: ["", nil]) }
+#validations
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :scheduled, presence: true
+  validates :finished, presence: true, on: :update
+  validates :priority, presence: true, uniqueness: true
+  validates :unfinished, presence: true
+#scope
+  scope :unfinished, -> { where(unfinished: ["1"]) }
+  scope :finished, -> { where(unfinished: ["0"]) }
   scope :asc, -> { order(scheduled: :ASC) }
   scope :desc, -> { order(finished: :DESC) }
 end

--- a/app/views/shared/_task.html.haml
+++ b/app/views/shared/_task.html.haml
@@ -8,4 +8,5 @@
       = task.finished
     .priority
       = task.priority
+    = link_to '完了', task_path(task, params:{task:{unfinished: false}}), class: 'finished_buttun', method: :put, data: {confirm: "このタスクを完了タスクに移動しますか?"}
     = link_to '削除', task_path(task), class: 'delete_buttun', method: :delete, data: {confirm: "このタスクを本当に削除しますか?"}

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -15,7 +15,8 @@
     .scheduled 予定日
     .finished 完了日
     .priority 優先順位
-    .delete
+    .finished_b
+    .delete_b
   -if @unfinished_tasks.count.to_i == 0
     .message_bar
       .message 未完了タスクがありません
@@ -38,7 +39,8 @@
     .scheduled 予定日
     .finished 完了日
     .priority 優先順位
-    .delete
+    .finished_b
+    .delete_b
   -if @finished_tasks.count.to_i == 0
     .message_bar
       .message 完了タスクがありません

--- a/db/migrate/20190609100309_create_tasks.rb
+++ b/db/migrate/20190609100309_create_tasks.rb
@@ -2,12 +2,13 @@ class CreateTasks < ActiveRecord::Migration
   def change
     create_table :tasks do |t|
 
-      t.timestamps         null: false
-      t.string :title,     null: false, index:true
-      t.text :body,        null: false
-      t.string :scheduled, null: false
-      t.string :finished
-      t.string :priority,  null: false
+      t.timestamps           null: false
+      t.string :title,       null: false, index:true
+      t.text :body,          null: false
+      t.date :scheduled,     null: false
+      t.date :finished
+      t.string :priority,    null: false
+      t.boolean :unfinished, null: false, default: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,13 +14,14 @@
 ActiveRecord::Schema.define(version: 20190609100309) do
 
   create_table "tasks", force: :cascade do |t|
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.string   "title",      limit: 255,   null: false
-    t.text     "body",       limit: 65535, null: false
-    t.string   "scheduled",  limit: 255,   null: false
-    t.string   "finished",   limit: 255
-    t.string   "priority",   limit: 255,   null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.string   "title",      limit: 255,                  null: false
+    t.text     "body",       limit: 65535,                null: false
+    t.date     "scheduled",                               null: false
+    t.date     "finished"
+    t.string   "priority",   limit: 255,                  null: false
+    t.boolean  "unfinished",               default: true, null: false
   end
 
   add_index "tasks", ["title"], name: "index_tasks_on_title", using: :btree


### PR DESCRIPTION
# What
•完了ボタンの実装
•閲覧・変更画面にて登録済みの値をフォームに表示
•入力・変更時のバリデーションの実装
# Why
•未完了タスクを完了させるため
•登録内容を確認するため
•フォーム項目の未入力を防ぐため
# 実装内容
•完了ボタンを押すと該当のタスクが未完了タスクから完了タスクへ移動する
•閲覧・変更画面にて登録済みの値をフォームに表示
•フォームに未入力の項目があった場合登録・変更ボタンを押しても登録・変更できない